### PR TITLE
ENTESB-11768:  [ER1] Camel-k doesn't work: The --maven-repository…

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -229,6 +229,7 @@ func (o *installCmdOptions) install(_ *cobra.Command, _ []string) error {
 						ActiveByDefault: true,
 					},
 					Repositories: repositories,
+					PluginRepositories: repositories,
 				},
 			}
 


### PR DESCRIPTION
Backport by cherry-picking: a923f643b8726046b73d2e1445ae78aadef5a5f5