### PR TITLE
Remove mod=vendor from defaults, we can pass this in in the PNC build

### DIFF
--- a/script/Makefile
+++ b/script/Makefile
@@ -47,7 +47,7 @@ PACKAGE_ARTIFACTS_STRATEGY := copy
 
 # Build
 GOLDFLAGS += -X github.com/apache/camel-k/pkg/cmd/operator.GitCommit=$(GIT_COMMIT)
-GOFLAGS = -mod=vendor -ldflags "$(GOLDFLAGS)" -trimpath
+GOFLAGS = -ldflags "$(GOLDFLAGS)" -trimpath
 
 define LICENSE_HEADER
 Licensed to the Apache Software Foundation (ASF) under one or more

--- a/script/embed_resources.sh
+++ b/script/embed_resources.sh
@@ -27,4 +27,4 @@ destdir=$1
 
 echo "Building virtual file system for the \"$destdir\" directory..."
 
-go run -mod=vendor ./cmd/util/vfs-gen/ $destdir
+go run ${GOFLAGS} ./cmd/util/vfs-gen/ $destdir


### PR DESCRIPTION
The -mod=vendor argument in GOFLAGS is causing issues in OSBS. I'd like to remove it from the defaults in camel-k.

The PNC build does need it, but we can pass it in through the GOFLAGS environment variable.