### PR TITLE
Add -mod=vendor to the go generate command

### DIFF
--- a/script/Makefile
+++ b/script/Makefile
@@ -190,7 +190,7 @@ endif
 
 build-resources:
 	./script/build_catalog.sh $(RUNTIME_VERSION) -Dcatalog.file=camel-catalog-$(RUNTIME_VERSION).yaml -Dcatalog.runtime=quarkus -Dstaging.repo="$(STAGING_RUNTIME_REPO)"
-	go generate ./pkg/...
+	go generate -mod=vendor ./pkg/...
 
 bundle-kamelets:
 ifneq (,$(findstring release,$(MAKECMDGOALS)))

--- a/script/build_catalog.sh
+++ b/script/build_catalog.sh
@@ -21,7 +21,7 @@ rootdir=$location/../
 if [ "$#" -ge 1 ]; then
   runtimeVersion="$1"
   shift 1
-  $rootdir/mvnw -q \
+  mvn -q \
     -f ${rootdir}/build/maven/pom-catalog.xml \
     -Denforcer.skip=true \
     -Dcatalog.path=${rootdir}/deploy \

--- a/script/gen_json_schema.sh
+++ b/script/gen_json_schema.sh
@@ -26,7 +26,7 @@ repo=$2
 [ -d "./tmpschema" ] && rm -r ./tmpschema
 mkdir  tmpschema
 
-./mvnw dependency:copy \
+mvn dependency:copy \
   -f build/maven/pom-catalog.xml \
   -Dartifact=org.apache.camel.k:camel-k-loader-yaml-impl:$version:json:json-schema \
   -DoutputDirectory=../../tmpschema \

--- a/script/package_maven_artifacts.sh
+++ b/script/package_maven_artifacts.sh
@@ -29,7 +29,7 @@ staging_repo=$3
 cd ${location}/..
 
 if [ "$strategy" = "copy" ]; then
-    ./mvnw \
+    mvn \
         -V \
         --no-transfer-progress \
         -f build/maven/pom-runtime.xml \
@@ -39,7 +39,7 @@ if [ "$strategy" = "copy" ]; then
         -Dalpn.jdk8.version="8.1.13.v20181017" \
         dependency:copy-dependencies
 elif [ "$strategy" = "download" ]; then
-    ./mvnw \
+    mvn \
         -V \
         --no-transfer-progress \
         -f build/maven/pom-runtime.xml \


### PR DESCRIPTION
Add -mod=vendor to the go generate command; replace uses of mvnw with mvn because of the PNC firewall.