### PR TITLE
Revert "Fix PNC build by forcing vendor mode during generation"

### DIFF
--- a/pkg/resources/resources_support.go
+++ b/pkg/resources/resources_support.go
@@ -28,7 +28,7 @@ import (
 )
 
 //
-//go:generate go run -mod=vendor ../../cmd/util/vfs-gen deploy config
+//go:generate go run ../../cmd/util/vfs-gen deploy config
 //
 // ResourceAsString returns the named resource content as string
 func ResourceAsString(name string) string {


### PR DESCRIPTION
This reverts commit 05f7bbffdc00d1e616fbdf3e1d43534af5e2fc51.

Revert the -mod=vendor annotation here, it'd be better to keep the mod=vendor flags to the Makefile so we can easily strip them when we have to do the OSBS build.