### PR TITLE
fix(cmd): run file system stat errors

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -410,7 +410,11 @@ func (o *runCmdOptions) syncIntegration(cmd *cobra.Command, c client.Client, sou
 	files = append(files, o.OpenAPIs...)
 
 	for _, s := range files {
-		if isLocalAndFileExists(s) {
+		ok, err := isLocalAndFileExists(s)
+		if err != nil {
+			return err
+		}
+		if ok {
 			changes, err := sync.File(o.Context, s)
 			if err != nil {
 				return err
@@ -762,12 +766,16 @@ func (o *runCmdOptions) configureTraits(integration *v1.Integration, options []s
 	return nil
 }
 
-func isLocalAndFileExists(fileName string) bool {
+func isLocalAndFileExists(fileName string) (bool, error) {
 	info, err := os.Stat(fileName)
-	if os.IsNotExist(err) {
-		return false
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		// If it is a different error (ie, permission denied) we should report it back
+		return false, errors.Wrap(err, fmt.Sprintf("file system error while looking for %s", fileName))
 	}
-	return !info.IsDir()
+	return !info.IsDir(), nil
 }
 
 func addIntegrationProperties(props *properties.Properties, spec *v1.IntegrationSpec) error {

--- a/pkg/cmd/run_test.go
+++ b/pkg/cmd/run_test.go
@@ -527,3 +527,10 @@ func TestRunTextCompressedResource(t *testing.T) {
 	assert.Equal(t, "text/plain", textResourceSpec.ContentType)
 	assert.True(t, textResourceSpec.Compression)
 }
+
+func TestIsLocalFileAndExists(t *testing.T) {
+	value, err := isLocalAndFileExists("/root/test")
+	// must not panic because a permission error
+	assert.NotNil(t, err)
+	assert.False(t, value)
+}

--- a/pkg/cmd/util_content.go
+++ b/pkg/cmd/util_content.go
@@ -30,7 +30,12 @@ func loadRawContent(source string) ([]byte, string, error) {
 	var content []byte
 	var err error
 
-	if isLocalAndFileExists(source) {
+	ok, err := isLocalAndFileExists(source)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if ok {
 		content, err = ioutil.ReadFile(source)
 	} else {
 		u, err := url.Parse(source)

--- a/pkg/cmd/util_sources.go
+++ b/pkg/cmd/util_sources.go
@@ -65,7 +65,12 @@ func ResolveSources(ctx context.Context, locations []string, compress bool) ([]S
 	sources := make([]Source, 0, len(locations))
 
 	for _, location := range locations {
-		if isLocalAndFileExists(location) {
+		ok, err := isLocalAndFileExists(location)
+		if err != nil {
+			return sources, err
+		}
+
+		if ok {
 			answer, err := ResolveLocalSource(location, compress)
 			if err != nil {
 				return sources, err


### PR DESCRIPTION
* Introducing a check to make sure that we don't panic if any kind of filesystem error but file not found is reported
* Adding a unit test to check a permission error on /root won't panic