### PR TITLE
fix: Filter influencing traits to lookup matching kits

### DIFF
--- a/pkg/controller/integration/build_kit.go
+++ b/pkg/controller/integration/build_kit.go
@@ -129,7 +129,7 @@ func (action *buildKitAction) Handle(ctx context.Context, integration *v1.Integr
 	platformKit.Spec = v1.IntegrationKitSpec{
 		Dependencies: integration.Status.Dependencies,
 		Repositories: integration.Spec.Repositories,
-		Traits:       action.filterKitTraits(ctx, integration.Spec.Traits),
+		Traits:       filterKitTraits(ctx, action.client, integration.Spec.Traits),
 	}
 
 	if err := action.client.Create(ctx, &platformKit); err != nil {
@@ -141,21 +141,4 @@ func (action *buildKitAction) Handle(ctx context.Context, integration *v1.Integr
 	integration.SetIntegrationKit(&platformKit)
 
 	return integration, nil
-}
-
-func (action *buildKitAction) filterKitTraits(ctx context.Context, in map[string]v1.TraitSpec) map[string]v1.TraitSpec {
-	if len(in) == 0 {
-		return in
-	}
-	catalog := trait.NewCatalog(ctx, action.client)
-	out := make(map[string]v1.TraitSpec)
-	for name, conf := range in {
-		t := catalog.GetTrait(name)
-		if t != nil && !t.InfluencesKit() {
-			// We don't store the trait configuration if the trait cannot influence the kit behavior
-			continue
-		}
-		out[name] = conf
-	}
-	return out
 }


### PR DESCRIPTION
As a 1.4.1 release is considered for ENTESB-17309, this PR fixes fast-redeploy of Integrations in 1.4.0. This issue has been uncovered by @tmielke and @abouchama and discussed in https://chat.google.com/room/AAAAeFFdN0E/WCdR4MOJsSc. This regression, that only exists in 1.4 GA, affects an important feature that's marketed, so it may be worth piggy backing that PR in 1.4.1, as we don't want to keep delivering false promises.

/cc @nicolaferraro @heiko-braun 