### PR TITLE
Workaround ENTESB-17802 by changing the order of BOM imports. The pro…

### DIFF
--- a/pkg/builder/quarkus.go
+++ b/pkg/builder/quarkus.go
@@ -114,19 +114,19 @@ func GenerateQuarkusProjectCommon(camelQuarkusVersion string, runtimeVersion str
 	// DependencyManagement
 	p.DependencyManagement.Dependencies = append(p.DependencyManagement.Dependencies,
 		maven.Dependency{
-			GroupID:    "org.apache.camel.quarkus",
-			ArtifactID: "camel-quarkus-bom",
-			Version:    camelQuarkusVersion,
-			Type:       "pom",
-			Scope:      "import",
-		},
-		maven.Dependency{
 			GroupID:    "org.apache.camel.k",
 			ArtifactID: "camel-k-runtime-bom",
 			Version:    runtimeVersion,
 			Type:       "pom",
 			Scope:      "import",
 		},
+        maven.Dependency{
+            GroupID:    "org.apache.camel.quarkus",
+            ArtifactID: "camel-quarkus-bom",
+            Version:    camelQuarkusVersion,
+            Type:       "pom",
+            Scope:      "import",
+        },
 	)
 
 	// Plugins


### PR DESCRIPTION
…ductized camel-kamelet-reify is managed in camel-k-runtime-bom

See https://issues.redhat.com/browse/ENTESB-17802 and https://github.com/jboss-fuse/camel-k-runtime/pull/21