### PR TITLE
Fix rhi version to 2022.Q1 (metering label)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <camel.version>3.11.5</camel.version>
         <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
         <camel-quarkus.version>2.2.1</camel-quarkus.version>
-        <rhi.version>2021.Q4</rhi.version>
+        <rhi.version>2022.Q1</rhi.version>
         <base.image>registry.access.redhat.com/ubi8/openjdk-11:1.3</base.image>
         <image.name>registry.redhat.io/integration-tech-preview/camel-k-rhel8-operator</image.name>
         <deploy-plugin.version>2.8.2</deploy-plugin.version>


### PR DESCRIPTION
https://issues.redhat.com/browse/ENTESB-14406
