### PR TITLE
ENTESB-19495: Skips problematic 1.6.8 release

### DIFF
--- a/config/manifests/bases/camel-k.clusterserviceversion.yaml
+++ b/config/manifests/bases/camel-k.clusterserviceversion.yaml
@@ -26,6 +26,7 @@ metadata:
     createdAt: 1977-01-01T00:00:00Z
     description: Red Hat Integration - Camel K is a lightweight integration platform,
       born on Kubernetes, with serverless superpowers.
+    olm.skipRange: '>=1.6.7 <=1.6.8'
     operators.operatorframework.io/builder: operator-sdk-v1.3.0
     operators.operatorframework.io/internal-objects: '["builds.camel.apache.org","integrationkits.camel.apache.org","camelcatalogs.camel.apache.org"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
@@ -154,7 +155,6 @@ spec:
   provider:
     name: Red Hat
     url: https://access.redhat.com/products/red-hat-integration
-  replaces: red-hat-camel-k-operator.vA.B.C
   selector:
     matchLabels:
       name: camel-k-operator

--- a/helm/camel-k/Chart.yaml
+++ b/helm/camel-k/Chart.yaml
@@ -35,7 +35,7 @@ version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.6.8
+appVersion: 1.6.9
 
 icon: https://github.com/apache/camel/raw/main/docs/img/logo64-d.png
 home: https://camel.apache.org/camel-k/latest/

--- a/helm/camel-k/values.yaml
+++ b/helm/camel-k/values.yaml
@@ -23,7 +23,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 operator:
-  image: docker.io/apache/camel-k:1.6.8
+  image: docker.io/apache/camel-k:1.6.9
 
 platform:
   build:

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>org.fuse.camel.k</groupId>
     <artifactId>camel-k-parent</artifactId>
-    <version>1.6.8-SNAPSHOT</version>
+    <version>1.6.9-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Fuse :: Camel-K Parent</name>
@@ -36,7 +36,7 @@
     <inceptionYear>2011</inceptionYear>
 
     <properties>
-        <version.camel-k.release>1.6.8</version.camel-k.release>
+        <version.camel-k.release>1.6.9</version.camel-k.release>
         <camel.version>3.11.5</camel.version>
         <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
         <camel-quarkus.version>2.2.1</camel-quarkus.version>

--- a/script/Makefile
+++ b/script/Makefile
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 VERSIONFILE := pkg/util/defaults/defaults.go
-VERSION := 1.6.8
-LAST_RELEASED_VERSION := 1.6.7
+VERSION := 1.6.9
+LAST_RELEASED_VERSION := 1.6.8
 RHI_VERSION := 2022.Q2
 RUNTIME_VERSION := 1.9.0
 LAST_RELEASED_IMAGE_NAME := red-hat-camel-k-operator
@@ -59,6 +59,7 @@ CSV_NAME := $(PACKAGE).v$(CSV_VERSION)
 CSV_DISPLAY_NAME := Red Hat Integration - Camel K
 CSV_SUPPORT := Camel
 CSV_REPLACES := $(LAST_RELEASED_IMAGE_NAME).v$(LAST_RELEASED_VERSION)
+CSV_SKIPS := "'>=1.6.7 <=$(LAST_RELEASED_VERSION)'"
 CSV_FILENAME := $(PACKAGE).clusterserviceversion.yaml
 CSV_PATH := $(MANIFESTS)/bases/$(CSV_FILENAME)
 DEFAULT_CSV := $(MANIFESTS)/bases/camel-k.clusterserviceversion.yaml


### PR DESCRIPTION
* For new release of 1.6.9, define a skip rather than replace to allow
  users to workaround the probelmatic 1.6.8 release