### PR TITLE
chore(ci): enable downstream checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,61 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+version: 2
+updates:
+  - directory: "/"
+    open-pull-requests-limit: 5
+    package-ecosystem: "gomod"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "github.com/Masterminds/semver"
+      - dependency-name: "github.com/container-tools/spectrum"
+      - dependency-name: "github.com/fatih/structs"
+      - dependency-name: "github.com/gertd/go-pluralize"
+      - dependency-name: "github.com/go-logr/logr"
+      - dependency-name: "github.com/golangplus/testing"
+      - dependency-name: "github.com/google/go-github/v32"
+      - dependency-name: "github.com/google/uuid"
+      - dependency-name: "github.com/jpillora/backoff"
+      - dependency-name: "github.com/magiconair/properties"
+      - dependency-name: "github.com/mitchellh/go-homedir"
+      - dependency-name: "github.com/mitchellh/mapstructure"
+      - dependency-name: "github.com/onsi/gomega"
+      - dependency-name: "github.com/operator-framework/api"
+      - dependency-name: "github.com/pkg/errors"
+      - dependency-name: "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
+      - dependency-name: "github.com/prometheus/client_golang"
+      - dependency-name: "github.com/prometheus/client_model"
+      - dependency-name: "github.com/prometheus/common"
+      - dependency-name: "github.com/radovskyb/watcher"
+      - dependency-name: "github.com/redhat-developer/service-binding-operator"
+      - dependency-name: "github.com/rs/xid"
+      - dependency-name: "github.com/scylladb/go-set"
+      - dependency-name: "github.com/shurcooL/httpfs"
+      - dependency-name: "github.com/shurcooL/vfsgen"
+      - dependency-name: "github.com/sirupsen/logrus"
+      - dependency-name: "github.com/spf13/cobra"
+      - dependency-name: "github.com/spf13/pflag"
+      - dependency-name: "github.com/spf13/viper"
+      - dependency-name: "github.com/stoewer/go-strcase"
+      - dependency-name: "github.com/stretchr/testify"
+      - dependency-name: "go.uber.org/multierr"
+      - dependency-name: "go.uber.org/zap"
+      - dependency-name: "golang.org/x/oauth2"
+      - dependency-name: "gopkg.in/inf.v0"
+      - dependency-name: "gopkg.in/yaml.v2"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+<!-- Description -->
+
+
+
+
+<!--
+Enter your extended release note in the below block. If the PR requires
+additional action from users switching to the new release, include the string
+"action required". If no release note is required, write "NONE". 
+
+You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
+the text is added to the right section of the release notes. 
+-->
+
+**Release Note**
+```release-note
+NONE
+```

--- a/.github/workflows/automatic-changelog-update.yml
+++ b/.github/workflows/automatic-changelog-update.yml
@@ -1,0 +1,60 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: Changelog
+
+on:
+  schedule:
+    # Run at 3 during the night
+    - cron:  '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  generate_changelog:
+    runs-on: ubuntu-20.04
+    name: Generate changelog for main branch
+    if: github.ref == 'refs/heads/main' && github.repository == 'apache/camel-k'
+    steps:
+      - name: "Checkout camel-k"
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Generate changelog
+        uses: ./.github/actions/changelog
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release_branch: "main"
+
+      - name: Commit files
+        env:
+          CI_USER: "github-actions[bot]"
+          CI_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
+        run: |
+          git config --local user.email "$CI_EMAIL"
+          git config --local user.name "$CI_USER"
+          git add CHANGELOG.md && git commit -m 'Updated CHANGELOG.md' && echo "push=1" >> $GITHUB_ENV || echo "No changes to CHANGELOG.md"
+
+      - name: Push changes
+        if: env.push == 1
+        env:
+          CI_USER: "github-actions[bot]"
+          CI_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
+          CI_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git push "https://$CI_USER:$CI_TOKEN@github.com/$GITHUB_REPOSITORY.git" HEAD:main

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,38 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: Backport
+on:
+  pull_request:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    runs-on: ubuntu-20.04
+    name: Backport
+    steps:
+      - name: "Checkout camel-k"
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - name: Backport
+        uses: ./.github/actions/backport
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,77 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: build
+
+on:
+  pull_request:
+    branches:
+      - main
+      - "release-*"
+    paths-ignore:
+      - 'docs/**'
+      - 'proposals/**'
+      - '**.adoc'
+      - '**.md'
+      - 'KEYS'
+      - 'LICENSE'
+      - 'NOTICE'
+  push:
+    branches:
+      - main
+      - "release-*"
+    paths-ignore:
+      - 'docs/**'
+      - 'proposals/**'
+      - '**.md'
+      - '**.adoc'
+      - 'KEYS'
+      - 'LICENSE'
+      - 'NOTICE'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        # TODO: test an all the supported OS
+        # [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Set up JDK 11
+      uses: AdoptOpenJDK/install-jdk@v1
+      with:
+        version: "11"
+    - name: Install Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.16.x
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Cache modules
+      uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Test
+      run: make

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -1,0 +1,129 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: builder
+
+on:
+  pull_request:
+    branches:
+      - main
+      - "release-*"
+    paths-ignore:
+      - 'docs/**'
+      - 'proposals/**'
+      - '**.adoc'
+      - '**.md'
+      - 'KEYS'
+      - 'LICENSE'
+      - 'NOTICE'
+  push:
+    branches:
+      - main
+      - "release-*"
+    paths-ignore:
+      - 'docs/**'
+      - 'proposals/**'
+      - '**.adoc'
+      - '**.md'
+      - 'KEYS'
+      - 'LICENSE'
+      - 'NOTICE'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  builder-it:
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        publisher: ["Buildah", "Spectrum", "Kaniko"]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Cleanup
+      run: |
+        ls -lart
+        echo "Initial status:"
+        df -h
+
+        echo "Cleaning up resources:"
+        sudo swapoff -a
+        sudo rm -f /swapfile
+        sudo apt clean
+        docker rmi $(docker image ls -aq)
+
+        echo "Final status:"
+        df -h
+    - name: Set up JDK 11
+      uses: AdoptOpenJDK/install-jdk@v1
+      with:
+        version: "11"
+    - name: Set Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.16.x
+    - name: Kubernetes KinD Cluster
+      uses: container-tools/kind-action@v1
+      with:
+        version: v0.11.0
+        node_image: kindest/node:v1.21.1@sha256:fae9a58f17f18f06aeac9772ca8b5ac680ebbed985e266f711d936e91d113bad
+    - name: Info
+      run: |
+        kubectl cluster-info
+        kubectl describe nodes
+    - name: Build Operator
+      run: |
+        echo "Build project"
+        export CUSTOM_IMAGE=${KIND_REGISTRY}/apache/camel-k
+        echo "LOCAL_IMAGE_NAME=${CUSTOM_IMAGE}" >> $GITHUB_ENV
+        echo "LOCAL_IMAGE_VERSION=$(make get-version)" >> $GITHUB_ENV
+        make PACKAGE_ARTIFACTS_STRATEGY=download build package-artifacts images images-push
+
+        sudo mv ./kamel /usr/local/bin
+    - name: Run IT
+      # Disable registry tests as not compatible with KinD
+      #env:
+      #  TEST_DOCKER_HUB_USERNAME: ${{ secrets.TEST_DOCKER_HUB_USERNAME }}
+      #  TEST_DOCKER_HUB_PASSWORD: ${{ secrets.TEST_DOCKER_HUB_PASSWORD }}
+      #  TEST_GITHUB_PACKAGES_REPO: ${{ secrets.TEST_GITHUB_PACKAGES_REPO }}
+      #  TEST_GITHUB_PACKAGES_USERNAME: ${{ secrets.TEST_GITHUB_PACKAGES_USERNAME }}
+      #  TEST_GITHUB_PACKAGES_PASSWORD: ${{ secrets.TEST_GITHUB_PACKAGES_PASSWORD }}
+      env:
+        KAMEL_INSTALL_BUILD_PUBLISH_STRATEGY: ${{ matrix.publisher }}
+      run: |
+        echo "Installing camel k cluster resources"
+        kamel install --cluster-setup
+
+        # Configure install options
+        export CUSTOM_IMAGE=${{ env.LOCAL_IMAGE_NAME }}
+        export CUSTOM_VERSION=${{ env.LOCAL_IMAGE_VERSION }}
+        export KAMEL_INSTALL_MAVEN_REPOSITORIES=$(make get-staging-repo)
+        export KAMEL_INSTALL_REGISTRY=$KIND_REGISTRY
+        export KAMEL_INSTALL_REGISTRY_INSECURE=true
+        export KAMEL_INSTALL_OPERATOR_IMAGE=${CUSTOM_IMAGE}:${CUSTOM_VERSION}
+        export KAMEL_INSTALL_OPERATOR_ENV_VARS=KAMEL_INSTALL_DEFAULT_KAMELETS=false
+
+        # Configure test options
+        export CAMEL_K_TEST_IMAGE_NAME=${CUSTOM_IMAGE}
+        export CAMEL_K_TEST_IMAGE_VERSION=${CUSTOM_VERSION}
+
+        # Then run integration tests
+        make test-builder

--- a/.github/workflows/knative.yml
+++ b/.github/workflows/knative.yml
@@ -1,0 +1,285 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: knative
+
+on:
+  pull_request:
+    branches:
+      - main
+      - "release-*"
+    paths-ignore:
+      - 'docs/**'
+      - 'proposals/**'
+      - '**.adoc'
+      - '**.md'
+      - 'KEYS'
+      - 'LICENSE'
+      - 'NOTICE'
+  push:
+    branches:
+      - main
+      - "release-*"
+    paths-ignore:
+      - 'docs/**'
+      - 'proposals/**'
+      - '**.adoc'
+      - '**.md'
+      - 'KEYS'
+      - 'LICENSE'
+      - 'NOTICE'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Cleanup
+      run: |
+        ls -lart
+        echo "Initial status:"
+        df -h
+
+        echo "Cleaning up resources:"
+        sudo swapoff -a
+        sudo rm -f /swapfile
+        sudo apt clean
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf "/usr/local/share/boost"
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        docker rmi $(docker image ls -aq)
+
+        echo "Final status:"
+        df -h
+    - name: Set up JDK 11
+      uses: AdoptOpenJDK/install-jdk@v1
+      with:
+        version: "11"
+    - name: Set Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.16.x
+    - name: Kubernetes KinD Cluster
+      uses: container-tools/kind-action@v1
+      with:
+        version: v0.11.0
+        node_image: kindest/node:v1.21.1@sha256:fae9a58f17f18f06aeac9772ca8b5ac680ebbed985e266f711d936e91d113bad
+    - name: Info
+      run: |
+        kubectl version
+        kubectl cluster-info
+        kubectl describe nodes
+    - name: Install Knative
+      run: |
+        # Prerequisites
+        sudo wget https://github.com/mikefarah/yq/releases/download/v4.9.6/yq_linux_amd64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq
+
+        export SERVING_VERSION=knative-v1.1.0
+        export EVENTING_VERSION=knative-v1.1.0
+        export KOURIER_VERSION=knative-v1.1.0
+
+        # Serving
+        kubectl apply --filename https://github.com/knative/serving/releases/download/$SERVING_VERSION/serving-crds.yaml
+        curl -L -s https://github.com/knative/serving/releases/download/$SERVING_VERSION/serving-core.yaml | head -n -1 | yq e 'del(.spec.template.spec.containers[].resources)' - | kubectl apply -f -
+
+        # Kourier
+        kubectl apply --filename https://github.com/knative-sandbox/net-kourier/releases/download/$KOURIER_VERSION/kourier.yaml
+        kubectl patch configmap/config-network \
+        --namespace knative-serving \
+        --type merge \
+        --patch '{"data":{"ingress.class":"kourier.ingress.networking.knative.dev"}}'
+
+        # Eventing
+        kubectl apply --filename https://github.com/knative/eventing/releases/download/$EVENTING_VERSION/eventing-crds.yaml
+        curl -L -s https://github.com/knative/eventing/releases/download/$EVENTING_VERSION/eventing-core.yaml | head -n -1 | yq e 'del(.spec.template.spec.containers[].resources)' - | kubectl apply -f -
+
+        # Eventing channels
+        curl -L -s https://github.com/knative/eventing/releases/download/$EVENTING_VERSION/in-memory-channel.yaml | head -n -1 | yq e 'del(.spec.template.spec.containers[].resources)' - | kubectl apply -f -
+
+        # Eventing broker
+        curl -L -s https://github.com/knative/eventing/releases/download/$EVENTING_VERSION/mt-channel-broker.yaml | head -n -1 | yq e 'del(.spec.template.spec.containers[].resources)' - | kubectl apply -f -
+
+        # Eventing sugar controller for injection
+        kubectl apply -f https://github.com/knative/eventing/releases/download/$EVENTING_VERSION/eventing-sugar-controller.yaml
+
+        # Wait for installation completed
+        echo "Waiting for all pods to be ready in kourier-system"
+        kubectl wait --for=condition=Ready pod --all -n kourier-system --timeout=60s
+        echo "Waiting for all pods to be ready in knative-serving"
+        kubectl wait --for=condition=Ready pod --all -n knative-serving --timeout=60s
+        echo "Waiting for all pods to be ready in knative-eventing"
+        kubectl wait --for=condition=Ready pod --all -n knative-eventing --timeout=60s
+
+    - name: Build Operator
+      run: |
+        echo "Build project"
+        export CUSTOM_IMAGE=${KIND_REGISTRY}/apache/camel-k
+        echo "LOCAL_IMAGE_NAME=${CUSTOM_IMAGE}" >> $GITHUB_ENV
+        echo "LOCAL_IMAGE_VERSION=$(make get-version)" >> $GITHUB_ENV
+        make PACKAGE_ARTIFACTS_STRATEGY=download build package-artifacts images images-push
+
+        sudo mv ./kamel /usr/local/bin
+    - name: Run IT
+      run: |
+        echo "Installing camel k cluster resources"
+        kamel install --cluster-setup
+
+        # Configure install options
+        export CUSTOM_IMAGE=${{ env.LOCAL_IMAGE_NAME }}
+        export CUSTOM_VERSION=${{ env.LOCAL_IMAGE_VERSION }}
+        export KAMEL_INSTALL_BUILD_PUBLISH_STRATEGY=Spectrum
+        export KAMEL_INSTALL_MAVEN_REPOSITORIES=$(make get-staging-repo)
+        export KAMEL_INSTALL_REGISTRY=$KIND_REGISTRY
+        export KAMEL_INSTALL_REGISTRY_INSECURE=true
+        export KAMEL_INSTALL_OPERATOR_IMAGE=${CUSTOM_IMAGE}:${CUSTOM_VERSION}
+
+        # Configure test options
+        export CAMEL_K_TEST_IMAGE_NAME=${CUSTOM_IMAGE}
+        export CAMEL_K_TEST_IMAGE_VERSION=${CUSTOM_VERSION}
+
+        # Then run integration tests
+        make test-knative
+
+  yaks:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Cleanup
+        run: |
+          ls -lart
+          echo "Initial status:"
+          df -h
+
+          echo "Cleaning up resources:"
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          docker rmi $(docker image ls -aq)
+
+          echo "Final status:"
+          df -h
+      - name: Set up JDK 11
+        uses: AdoptOpenJDK/install-jdk@v1
+        with:
+          version: "11"
+      - name: Set Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.16.x
+      - name: Get YAKS
+        run: |
+          export YAKS_VERSION=0.4.0
+          curl --fail -L https://github.com/citrusframework/yaks/releases/download/v${YAKS_VERSION}/yaks-${YAKS_VERSION}-linux-64bit.tar.gz -o yaks.tar.gz
+          tar -zxf yaks.tar.gz
+          sudo mv yaks /usr/local/bin/
+      - name: Kubernetes KinD Cluster
+        uses: container-tools/kind-action@v1
+        with:
+          version: v0.11.0
+          node_image: kindest/node:v1.21.1@sha256:fae9a58f17f18f06aeac9772ca8b5ac680ebbed985e266f711d936e91d113bad
+      - name: Info
+        run: |
+          kubectl version
+          kubectl cluster-info
+          kubectl describe nodes
+      - name: Install YAKS
+        run: |
+          yaks install --cluster-setup
+      - name: Install Knative
+        run: |
+          # Prerequisites
+          sudo wget https://github.com/mikefarah/yq/releases/download/v4.9.6/yq_linux_amd64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq
+
+          export SERVING_VERSION=knative-v1.1.0
+          export EVENTING_VERSION=knative-v1.1.0
+          export KOURIER_VERSION=knative-v1.1.0
+
+          # Serving
+          kubectl apply --filename https://github.com/knative/serving/releases/download/$SERVING_VERSION/serving-crds.yaml
+          curl -L -s https://github.com/knative/serving/releases/download/$SERVING_VERSION/serving-core.yaml | head -n -1 | yq e 'del(.spec.template.spec.containers[].resources)' - | kubectl apply -f -
+
+          # Kourier
+          kubectl apply --filename https://github.com/knative-sandbox/net-kourier/releases/download/$KOURIER_VERSION/kourier.yaml
+          kubectl patch configmap/config-network \
+          --namespace knative-serving \
+          --type merge \
+          --patch '{"data":{"ingress.class":"kourier.ingress.networking.knative.dev"}}'
+
+          # Eventing
+          kubectl apply --filename https://github.com/knative/eventing/releases/download/$EVENTING_VERSION/eventing-crds.yaml
+          curl -L -s https://github.com/knative/eventing/releases/download/$EVENTING_VERSION/eventing-core.yaml | head -n -1 | yq e 'del(.spec.template.spec.containers[].resources)' - | kubectl apply -f -
+
+          # Eventing channels
+          curl -L -s https://github.com/knative/eventing/releases/download/$EVENTING_VERSION/in-memory-channel.yaml | head -n -1 | yq e 'del(.spec.template.spec.containers[].resources)' - | kubectl apply -f -
+
+          # Eventing broker
+          curl -L -s https://github.com/knative/eventing/releases/download/$EVENTING_VERSION/mt-channel-broker.yaml | head -n -1 | yq e 'del(.spec.template.spec.containers[].resources)' - | kubectl apply -f -
+
+          # Eventing sugar controller for injection
+          kubectl apply -f https://github.com/knative/eventing/releases/download/$EVENTING_VERSION/eventing-sugar-controller.yaml
+
+          # Wait for installation completed
+          echo "Waiting for all pods to be ready in kourier-system"
+          kubectl wait --for=condition=Ready pod --all -n kourier-system --timeout=60s
+          echo "Waiting for all pods to be ready in knative-serving"
+          kubectl wait --for=condition=Ready pod --all -n knative-serving --timeout=60s
+          echo "Waiting for all pods to be ready in knative-eventing"
+          kubectl wait --for=condition=Ready pod --all -n knative-eventing --timeout=60s
+
+      - name: Build Operator
+        run: |
+          echo "Build project"
+          export CUSTOM_IMAGE=${KIND_REGISTRY}/apache/camel-k
+          echo "LOCAL_IMAGE_NAME=${CUSTOM_IMAGE}" >> $GITHUB_ENV
+          echo "LOCAL_IMAGE_VERSION=$(make get-version)" >> $GITHUB_ENV
+          make PACKAGE_ARTIFACTS_STRATEGY=download build package-artifacts images images-push
+
+          sudo mv ./kamel /usr/local/bin
+      - name: Run IT
+        run: |
+          echo "Installing camel k cluster resources"
+          kamel install --cluster-setup
+
+          # Configure install options
+          export CUSTOM_IMAGE=${{ env.LOCAL_IMAGE_NAME }}
+          export CUSTOM_VERSION=${{ env.LOCAL_IMAGE_VERSION }}
+          export KAMEL_INSTALL_BUILD_PUBLISH_STRATEGY=Spectrum
+          export KAMEL_INSTALL_MAVEN_REPOSITORIES=$(make get-staging-repo)
+          export KAMEL_INSTALL_REGISTRY=$KIND_REGISTRY
+          export KAMEL_INSTALL_REGISTRY_INSECURE=true
+          export KAMEL_INSTALL_OPERATOR_IMAGE=${CUSTOM_IMAGE}:${CUSTOM_VERSION}
+
+          # Configure test options
+          export CAMEL_K_TEST_IMAGE_NAME=$KIND_REGISTRY/apache/camel-k
+          export CAMEL_K_TEST_IMAGE_VERSION=${CUSTOM_VERSION}
+
+          # Install Yaks globally
+          yaks install
+
+          # Then run integration tests
+          yaks test e2e/yaks/common

--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -1,0 +1,131 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: kubernetes
+
+on:
+  pull_request:
+    branches:
+      - main
+      - "release-*"
+    paths-ignore:
+      - 'docs/**'
+      - 'proposals/**'
+      - '**.adoc'
+      - '**.md'
+      - 'KEYS'
+      - 'LICENSE'
+      - 'NOTICE'
+  push:
+    branches:
+      - main
+      - "release-*"
+    paths-ignore:
+      - 'docs/**'
+      - 'proposals/**'
+      - '**.adoc'
+      - '**.md'
+      - 'KEYS'
+      - 'LICENSE'
+      - 'NOTICE'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  kubernetes-it:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Cleanup
+      run: |
+        ls -lart
+        echo "Initial status:"
+        df -h
+
+        echo "Cleaning up resources:"
+        sudo swapoff -a
+        sudo rm -f /swapfile
+        sudo apt clean
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf "/usr/local/share/boost"
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        docker rmi $(docker image ls -aq)
+
+        echo "Final status:"
+        df -h
+    - name: Set up JDK 11
+      uses: AdoptOpenJDK/install-jdk@v1
+      with:
+        version: "11"
+    - name: Set Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.16.x
+    - name: Kubernetes KinD Cluster
+      uses: container-tools/kind-action@v1
+      with:
+        version: v0.11.0
+        node_image: kindest/node:v1.21.1@sha256:fae9a58f17f18f06aeac9772ca8b5ac680ebbed985e266f711d936e91d113bad
+    - name: Info
+      run: |
+        kubectl cluster-info
+        kubectl describe nodes
+    - name: Build Operator
+      run: |
+        echo "Build project"
+        export CUSTOM_IMAGE=${KIND_REGISTRY}/apache/camel-k
+        echo "LOCAL_IMAGE_NAME=${CUSTOM_IMAGE}" >> $GITHUB_ENV
+        echo "LOCAL_IMAGE_VERSION=$(make get-version)" >> $GITHUB_ENV
+        make PACKAGE_ARTIFACTS_STRATEGY=download build package-artifacts images images-push
+
+        sudo mv ./kamel /usr/local/bin
+    - name: Run IT
+      # Disable registry tests as not compatible with KinD
+      #env:
+      #  TEST_DOCKER_HUB_USERNAME: ${{ secrets.TEST_DOCKER_HUB_USERNAME }}
+      #  TEST_DOCKER_HUB_PASSWORD: ${{ secrets.TEST_DOCKER_HUB_PASSWORD }}
+      #  TEST_GITHUB_PACKAGES_REPO: ${{ secrets.TEST_GITHUB_PACKAGES_REPO }}
+      #  TEST_GITHUB_PACKAGES_USERNAME: ${{ secrets.TEST_GITHUB_PACKAGES_USERNAME }}
+      #  TEST_GITHUB_PACKAGES_PASSWORD: ${{ secrets.TEST_GITHUB_PACKAGES_PASSWORD }}
+      run: |
+        echo "Installing camel k cluster resources"
+        kamel install --cluster-setup
+
+        # Configure install options
+        export CUSTOM_IMAGE=${{ env.LOCAL_IMAGE_NAME }}
+        export CUSTOM_VERSION=${{ env.LOCAL_IMAGE_VERSION }}
+        export KAMEL_INSTALL_BUILD_PUBLISH_STRATEGY=Spectrum
+        export KAMEL_INSTALL_MAVEN_REPOSITORIES=$(make get-staging-repo)
+        export KAMEL_INSTALL_REGISTRY=$KIND_REGISTRY
+        export KAMEL_INSTALL_REGISTRY_INSECURE=true
+        export KAMEL_INSTALL_OPERATOR_IMAGE=${CUSTOM_IMAGE}:${CUSTOM_VERSION}
+
+        # Configure test options
+        export CAMEL_K_TEST_IMAGE_NAME=${CUSTOM_IMAGE}
+        export CAMEL_K_TEST_IMAGE_VERSION=${CUSTOM_VERSION}
+
+        # Then run integration tests
+        make test-integration
+        make test-service-binding
+        make test-quarkus-native
+        make test-kustomize

--- a/.github/workflows/local.yml
+++ b/.github/workflows/local.yml
@@ -1,0 +1,91 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: local
+
+on:
+  pull_request:
+    branches:
+      - main
+      - "release-*"
+    paths-ignore:
+      - 'docs/**'
+      - 'proposals/**'
+      - '**.adoc'
+      - '**.md'
+      - 'KEYS'
+      - 'LICENSE'
+      - 'NOTICE'
+  push:
+    branches:
+      - main
+      - "release-*"
+    paths-ignore:
+      - 'docs/**'
+      - 'proposals/**'
+      - '**.adoc'
+      - '**.md'
+      - 'KEYS'
+      - 'LICENSE'
+      - 'NOTICE'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  local-it:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Cleanup
+      run: |
+        ls -lart
+        echo "Initial status:"
+        df -h
+
+        echo "Cleaning up resources:"
+        sudo swapoff -a
+        sudo rm -f /swapfile
+        sudo apt clean
+        docker rmi $(docker image ls -aq)
+
+        echo "Final status:"
+        df -h
+    - name: Set up JDK 11
+      uses: AdoptOpenJDK/install-jdk@v1
+      with:
+        version: "11"
+    - name: Set Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.16.x
+    - name: Build Kamel
+      run: |
+        echo "Build project"
+        make build-kamel
+        sudo mv ./kamel /usr/local/bin
+    - name: Run IT
+      run: |
+        # Configure staging repos
+        export KAMEL_LOCAL_RUN_MAVEN_REPOSITORIES=$(make get-staging-repo)
+
+        # Then run integration tests
+        make test-local

--- a/.github/workflows/openshift.yml
+++ b/.github/workflows/openshift.yml
@@ -1,0 +1,252 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: openshift
+
+on:
+  pull_request:
+    branches:
+      - main
+      - "release-*"
+    paths-ignore:
+      - 'docs/**'
+      - 'proposals/**'
+      - '**.adoc'
+      - '**.md'
+      - 'KEYS'
+      - 'LICENSE'
+      - 'NOTICE'
+  push:
+    branches:
+      - main
+      - "release-*"
+    paths-ignore:
+      - 'docs/**'
+      - 'proposals/**'
+      - '**.adoc'
+      - '**.md'
+      - 'KEYS'
+      - 'LICENSE'
+      - 'NOTICE'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: openshift-build
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Cleanup
+      run: |
+        ls -lart
+        echo "Initial status:"
+        df -h
+
+        echo "Cleaning up resources:"
+        sudo swapoff -a
+        sudo rm -f /swapfile
+        sudo apt clean
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf "/usr/local/share/boost"
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        docker rmi $(docker image ls -aq)
+
+        echo "Final status:"
+        df -h
+    - name: Set up JDK 11
+      uses: AdoptOpenJDK/install-jdk@v1
+      with:
+        version: "11"
+    - name: Set Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.16.x
+    - name: Get OpenShift Client (oc)
+      run: |
+        export OPENSHIFT_VERSION=v3.11.0
+        export OPENSHIFT_COMMIT=0cbc58b
+        export MAVEN_OPTS=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+
+        sudo rm -f /etc/resolv.conf
+        sudo ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf
+        sudo sh -c 'echo "DNS=8.8.8.8 4.4.4.4" >> /etc/systemd/resolved.conf'
+        sudo service systemd-resolved restart
+
+        # set docker0 to promiscuous mode
+        sudo ip link set docker0 promisc on
+
+        # Download and install the oc binary
+        sudo mount --make-shared /
+
+        sudo service docker stop
+        sudo echo '{"insecure-registries": ["172.30.0.0/16"]}' | sudo tee /etc/docker/daemon.json > /dev/null
+        sudo service docker start
+
+        DOWNLOAD_URL=https://github.com/openshift/origin/releases/download/$OPENSHIFT_VERSION/openshift-origin-client-tools-$OPENSHIFT_VERSION-$OPENSHIFT_COMMIT-linux-64bit.tar.gz
+        wget -O client.tar.gz ${DOWNLOAD_URL}
+        tar xvzOf client.tar.gz > oc.bin
+        sudo mv oc.bin /usr/local/bin/oc
+        sudo chmod 755 /usr/local/bin/oc
+
+    - name: Start OpenShift Cluster
+      run: |
+        # Figure out this host's IP address
+        IP_ADDR="$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)"
+
+        # Setup cluster dir
+        sudo mkdir -p /home/runner/lib/oc
+        sudo chmod 777 /home/runner/lib/oc
+        cd /home/runner/lib/oc
+
+        # Start OpenShift
+        oc cluster up --public-hostname=$IP_ADDR --enable=persistent-volumes,registry,router
+        oc login -u system:admin
+
+        # Wait until we have a ready node in openshift
+        TIMEOUT=0
+        TIMEOUT_COUNT=60
+        until [ $TIMEOUT -eq $TIMEOUT_COUNT ]; do
+          if [ -n "$(oc get nodes | grep Ready)" ]; then
+            break
+          fi
+          echo "openshift is not up yet"
+          TIMEOUT=$((TIMEOUT+1))
+          sleep 5
+        done
+
+        if [ $TIMEOUT -eq $TIMEOUT_COUNT ]; then
+          echo "Failed to start openshift"
+          exit 1
+        fi
+
+        echo "openshift is deployed and reachable"
+
+    - name: Info
+      run: |
+        oc describe nodes
+    - name: Run IT
+      #env:
+      #  TEST_DOCKER_HUB_USERNAME: ${{ secrets.TEST_DOCKER_HUB_USERNAME }}
+      #  TEST_DOCKER_HUB_PASSWORD: ${{ secrets.TEST_DOCKER_HUB_PASSWORD }}
+      #  TEST_GITHUB_PACKAGES_REPO: ${{ secrets.TEST_GITHUB_PACKAGES_REPO }}
+      #  TEST_GITHUB_PACKAGES_USERNAME: ${{ secrets.TEST_GITHUB_PACKAGES_USERNAME }}
+      #  TEST_GITHUB_PACKAGES_PASSWORD: ${{ secrets.TEST_GITHUB_PACKAGES_PASSWORD }}
+      run: |
+        # Compute registry parameters
+        echo "Build project"
+
+        make PACKAGE_ARTIFACTS_STRATEGY=download build package-artifacts images
+
+        # Make the Apache Snapshots or Apache Staging repository enabled by default
+        export KAMEL_INSTALL_MAVEN_REPOSITORIES=$(make get-staging-repo)
+
+        echo "installing camel k cluster resources"
+        ./kamel install --cluster-setup
+
+        # Aggregate pod eviction permission to the default admin role
+        cat <<EOF | oc apply -f -
+        kind: ClusterRole
+        apiVersion: rbac.authorization.k8s.io/v1
+        metadata:
+          name: camel-k-test:eviction
+          labels:
+            rbac.authorization.k8s.io/aggregate-to-admin: "true"
+        rules:
+        - apiGroups: [""]
+          resources: ["pods/eviction"]
+          verbs: ["create"]
+        EOF
+
+        # Grant nodes permission to the default developer user
+        cat <<EOF | oc apply -f -
+        kind: ClusterRole
+        apiVersion: rbac.authorization.k8s.io/v1
+        metadata:
+          name: camel-k-test:nodes
+        rules:
+        - apiGroups: [""]
+          resources: ["nodes"]
+          verbs: ["get","list"]
+        EOF
+        cat <<EOF | oc apply -f -
+        kind: ClusterRoleBinding
+        apiVersion: rbac.authorization.k8s.io/v1
+        metadata:
+          name: camel-k-test:nodes
+        subjects:
+        - kind: User
+          name: developer
+        roleRef:
+          kind: ClusterRole
+          name: camel-k-test:nodes
+          apiGroup: rbac.authorization.k8s.io
+        EOF
+
+        # Aggregate finalizers permission to the default admin role
+        cat <<EOF | oc apply -f -
+        kind: ClusterRole
+        apiVersion: rbac.authorization.k8s.io/v1
+        metadata:
+          name: camel-k-test:finalizers
+          labels:
+            rbac.authorization.k8s.io/aggregate-to-admin: "true"
+        rules:
+        - apiGroups: ["camel.apache.org"]
+          resources: ["*/finalizers"]
+          verbs: ["update"]
+        EOF
+
+        # Grant read permission on the Kubernetes Service to the default developer user
+        # Required by the HTTP proxy tests
+        cat <<EOF | oc apply -f -
+        kind: ClusterRole
+        apiVersion: rbac.authorization.k8s.io/v1
+        metadata:
+          name: camel-k-test:kubernetes-service
+        rules:
+        - apiGroups: [""]
+          resources: ["services"]
+          verbs: ["get"]
+          resourceNames: ["kubernetes"]
+        EOF
+        cat <<EOF | oc apply -f -
+        kind: RoleBinding
+        apiVersion: rbac.authorization.k8s.io/v1
+        metadata:
+          namespace: default
+          name: camel-k-test:kubernetes-service
+        subjects:
+        - kind: User
+          name: developer
+        roleRef:
+          kind: ClusterRole
+          name: camel-k-test:kubernetes-service
+          apiGroup: rbac.authorization.k8s.io
+        EOF
+
+        # Login as normal user
+        oc login -u developer
+
+        # Then run integration tests
+        make test-integration
+        make test-builder

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,132 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: release
+
+on:
+  push:
+    tags:
+      - '*nightly*'
+
+jobs:
+  release:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Set up JDK 11
+      uses: AdoptOpenJDK/install-jdk@v1
+      with:
+        version: "11"
+    - name: Install Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.16.x
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Cache modules
+      uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
+    - name: Global Env
+      env:
+        TEST_DOCKER_HUB_USERNAME: ${{ secrets.TEST_DOCKER_HUB_USERNAME }}
+        TEST_DOCKER_HUB_PASSWORD: ${{ secrets.TEST_DOCKER_HUB_PASSWORD }}
+      run: |
+        TAG=${GITHUB_REF##*/}
+        VERSION=${TAG:1}
+        echo "Using VERSION=$VERSION"
+        echo "::set-env name=VERSION::$VERSION"
+
+        IMAGE_NAME=docker.io/${TEST_DOCKER_HUB_USERNAME:-testcamelk}/camel-k
+        echo "Using IMAGE_NAME=$IMAGE_NAME"
+        echo "::set-env name=IMAGE_NAME::$IMAGE_NAME"
+
+        MAVEN_REPOSITORY=$(make get-staging-repo)
+        echo "Using MAVEN_REPOSITORY=$MAVEN_REPOSITORY"
+        echo "::set-env name=MAVEN_REPOSITORY::$MAVEN_REPOSITORY"
+
+        docker login -u $TEST_DOCKER_HUB_USERNAME -p $TEST_DOCKER_HUB_PASSWORD
+
+    - name: Codegen
+      run: |
+        make VERSION=$VERSION IMAGE_NAME=$IMAGE_NAME codegen set-version build-resources
+
+    - name: Build
+      run: |
+        make VERSION=$VERSION IMAGE_NAME=$IMAGE_NAME release-nightly
+
+    - name: Check
+      run: ls -l
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@latest
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ env.VERSION }}
+        release_name: Release ${{ env.VERSION }}
+        body: |
+          Apache Camel K nightly build for testing (unstable).
+
+          To test it, download the client for your OS and run:
+
+          ```
+          kamel install --olm=false --maven-repository=${{ env.MAVEN_REPOSITORY }}
+          ```
+
+        draft: false
+        prerelease: true
+    - name: Upload Client Linux
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./camel-k-client-${{ env.VERSION }}-linux-64bit.tar.gz
+        asset_name: camel-k-client-${{ env.VERSION }}-linux-64bit.tar.gz
+        asset_content_type: application/tar+gzip
+    - name: Upload Client Mac
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./camel-k-client-${{ env.VERSION }}-mac-64bit.tar.gz
+        asset_name: camel-k-client-${{ env.VERSION }}-mac-64bit.tar.gz
+        asset_content_type: application/tar+gzip
+    - name: Upload Client Windows
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./camel-k-client-${{ env.VERSION }}-windows-64bit.tar.gz
+        asset_name: camel-k-client-${{ env.VERSION }}-windows-64bit.tar.gz
+        asset_content_type: application/tar+gzip
+    - name: Upload Examples
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./camel-k-examples-${{ env.VERSION }}.tar.gz
+        asset_name: camel-k-examples-${{ env.VERSION }}.tar.gz
+        asset_content_type: application/tar+gzip

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,47 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: "Stale"
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-stale: 90
+        days-before-close: 15
+        operations-per-run: 10
+        stale-issue-label: status/stale
+        exempt-issue-label: status/never-stale
+        stale-issue-message: |
+          This issue has been automatically marked as stale due to 90 days of inactivity. 
+          It will be closed if no further activity occurs within 15 days.
+          If you think that’s incorrect or the issue should never stale, please simply write any comment.
+          Thanks for your contributions!
+        stale-pr-label: status/stale
+        exempt-pr-label: status/never-stale
+        stale-pr-message: |
+          This PR has been automatically marked as stale due to 90 days of inactivity. 
+          It will be closed if no further activity occurs within 15 days.
+          If you think that’s incorrect or the issue should never stale, please simply write any comment.
+          Thanks for your contributions!

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -1,0 +1,166 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: upgrade
+
+on:
+  pull_request:
+    branches:
+      - main
+      - "release-*"
+    paths-ignore:
+      - 'docs/**'
+      - 'proposals/**'
+      - '**.adoc'
+      - '**.md'
+      - 'KEYS'
+      - 'LICENSE'
+      - 'NOTICE'
+  push:
+    branches:
+      - main
+      - "release-*"
+    paths-ignore:
+      - 'docs/**'
+      - 'proposals/**'
+      - '**.adoc'
+      - '**.md'
+      - 'KEYS'
+      - 'LICENSE'
+      - 'NOTICE'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  upgrade:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Cleanup
+      run: |
+        ls -lart
+        echo "Initial status:"
+        df -h
+
+        echo "Cleaning up resources:"
+        sudo swapoff -a
+        sudo rm -f /swapfile
+        sudo apt clean
+        docker rmi $(docker image ls -aq)
+
+        echo "Final status:"
+        df -h
+    - name: Set up JDK 11
+      uses: AdoptOpenJDK/install-jdk@v1
+      with:
+        version: "11"
+    - name: Set Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16.x
+    - name: Set up opm tool
+      run: |
+        curl -L https://github.com/operator-framework/operator-registry/releases/download/v1.19.5/linux-amd64-opm -o opm
+        chmod +x opm
+        sudo mv opm /usr/local/bin/
+    - name: Kubernetes KinD Cluster
+      uses: container-tools/kind-action@v1
+      with:
+        version: v0.11.0
+        node_image: kindest/node:v1.21.1@sha256:fae9a58f17f18f06aeac9772ca8b5ac680ebbed985e266f711d936e91d113bad
+    - name: Info
+      run: |
+        kubectl cluster-info
+        kubectl describe nodes
+    - name: Install OLM
+      run: |
+        kubectl apply -f https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.17.0/crds.yaml
+        # wait for a while to be sure CRDs are installed
+        sleep 1
+        kubectl apply -f https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.17.0/olm.yaml
+    - name: Get Kamel CLI
+      run: |
+        export KAMEL_VERSION=$(make get-last-released-version)
+        curl -L https://github.com/apache/camel-k/releases/download/v${KAMEL_VERSION}/camel-k-client-${KAMEL_VERSION}-linux-64bit.tar.gz -o kamel.tar.gz
+        tar -zxf kamel.tar.gz
+        sudo mv kamel /usr/local/bin/
+    - name: Build Operator
+      run: |
+        echo "Build project"
+        export CUSTOM_IMAGE=${KIND_REGISTRY}/apache/camel-k
+        echo "LOCAL_IMAGE_NAME=${CUSTOM_IMAGE}" >> $GITHUB_ENV
+        echo "LOCAL_IMAGE_VERSION=$(make get-version)" >> $GITHUB_ENV
+        make PACKAGE_ARTIFACTS_STRATEGY=download build package-artifacts images images-push
+    - name: Build Operator bundle
+      run: |
+        echo "Build Operator bundle"
+
+        # reinstall kustomize to be always on the same version
+        sudo rm $(which kustomize)
+
+        make kustomize
+
+        # replace image
+        $(cd config/manifests && kustomize edit set image "docker.io/apache/camel-k=${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_VERSION }}")
+
+        # Patch CSV with the 'replaces' field to define the upgrade graph
+        # Use sed as the manifest/bases file is not included in the kustomize config
+        BASE_VERSION=$(echo ${{ env.LOCAL_IMAGE_VERSION }} | grep -Po "\d.\d.\d")
+        sed -i "/  version: ${BASE_VERSION}/a \ \ replaces: camel-k-operator.v$(make get-last-released-version)" config/manifests/bases/camel-k.clusterserviceversion.yaml
+        export CUSTOM_IMAGE=${{ env.LOCAL_IMAGE_NAME }}
+        export LOCAL_IMAGE_BUNDLE=${KIND_REGISTRY}/apache/camel-k-bundle:${{ env.LOCAL_IMAGE_VERSION }}
+        echo "LOCAL_IMAGE_BUNDLE=${LOCAL_IMAGE_BUNDLE}" >> $GITHUB_ENV
+        export PREV_XY_CHANNEL=stable-$(make get-last-released-version | grep -Po "\d.\d")
+        echo "PREV_XY_CHANNEL=${PREV_XY_CHANNEL}" >> $GITHUB_ENV
+        export NEW_XY_CHANNEL=stable-$(make get-version | grep -Po "\d.\d")
+        echo "NEW_XY_CHANNEL=${NEW_XY_CHANNEL}" >> $GITHUB_ENV
+        make bundle-build BUNDLE_IMAGE_NAME=${LOCAL_IMAGE_BUNDLE} DEFAULT_CHANNEL="${NEW_XY_CHANNEL}" CHANNELS="${NEW_XY_CHANNEL}"
+        docker push ${LOCAL_IMAGE_BUNDLE}
+    - name: Create new index image
+      run: |
+        export LOCAL_IIB=${KIND_REGISTRY}/apache/camel-k-iib:${{ env.LOCAL_IMAGE_VERSION }}
+        echo "LOCAL_IIB=${LOCAL_IIB}" >> $GITHUB_ENV
+        sudo opm index add --bundles ${{ env.LOCAL_IMAGE_BUNDLE }} -c docker --from-index quay.io/operatorhubio/catalog:latest --tag ${LOCAL_IIB} --skip-tls
+        docker push ${LOCAL_IIB}
+    - name: Run IT
+      run: |
+        # Use the last released Kamel CLI
+        export RELEASED_KAMEL_BIN=/usr/local/bin/kamel
+
+        # Configure install options
+        export CUSTOM_IMAGE=${{ env.LOCAL_IMAGE_NAME }}
+        export CUSTOM_VERSION=${{ env.LOCAL_IMAGE_VERSION }}
+        export KAMEL_INSTALL_BUILD_PUBLISH_STRATEGY=Spectrum
+        export KAMEL_INSTALL_MAVEN_REPOSITORIES=$(make get-staging-repo)
+        export KAMEL_INSTALL_REGISTRY=${KIND_REGISTRY}
+        export KAMEL_INSTALL_REGISTRY_INSECURE=true
+
+        # Configure test options
+        export CAMEL_K_PREV_IIB=quay.io/operatorhubio/catalog:latest
+        export CAMEL_K_NEW_IIB=${{ env.LOCAL_IIB }}
+        export KAMEL_K_TEST_RELEASE_VERSION=$(make get-last-released-version)
+        export KAMEL_K_TEST_OPERATOR_CURRENT_IMAGE=${CUSTOM_IMAGE}:${CUSTOM_VERSION}
+        export CAMEL_K_PREV_UPGRADE_CHANNEL=${{ env.PREV_XY_CHANNEL }}
+        export CAMEL_K_NEW_UPGRADE_CHANNEL=${{ env.NEW_XY_CHANNEL }}
+
+        # Then run integration tests
+        make test-upgrade

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,51 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: validate
+
+on: 
+  pull_request:
+    branches: 
+      - main
+      - "release-*"
+  push:
+    branches:
+      - main
+      - "release-*"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.16.x
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        env:
+          GOGC: 20
+        with:
+          version: v1.43.0
+          skip-go-installation: true
+          args: --verbose --deadline 15m --config .golangci.yml

--- a/pkg/cmd/trait_help_test.go
+++ b/pkg/cmd/trait_help_test.go
@@ -1,3 +1,4 @@
+//go:build common
 // +build common
 
 /*

--- a/pkg/cmd/uninstall.go
+++ b/pkg/cmd/uninstall.go
@@ -333,7 +333,6 @@ func (o *uninstallCmdOptions) uninstallRolesFromNamespace(ctx context.Context, c
 	return nil
 }
 
-
 func (o *uninstallCmdOptions) uninstallRoleBindings(ctx context.Context, c client.Client) error {
 	err := o.uninstallRoleBindingsFromNamespace(ctx, c, o.Namespace)
 	if err != nil {

--- a/script/Makefile
+++ b/script/Makefile
@@ -402,7 +402,7 @@ get-staging-repo:
 
 # find or download controller-gen if necessary
 controller-gen:
-ifeq (, $(shell command -v controller-gen))
+ifeq (, $(shell which controller-gen))
 	@{ \
 	set -e ;\
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
@@ -413,16 +413,16 @@ ifeq (, $(shell command -v controller-gen))
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen
 else
-CONTROLLER_GEN=$(shell command -v controller-gen)
+CONTROLLER_GEN=$(shell which controller-gen)
 endif
 
 kubectl:
-ifeq (, $(shell command -v kubectl))
+ifeq (, $(shell which kubectl))
 	$(error "No kubectl found in PATH. Please install and re-run")
 endif
 
 kustomize:
-ifeq (, $(shell command -v kustomize))
+ifeq (, $(shell which kustomize))
 	@{ \
 	set -e ;\
 	KUSTOMIZE_GEN_TMP_DIR=$$(mktemp -d) ;\
@@ -433,11 +433,11 @@ ifeq (, $(shell command -v kustomize))
 	}
 KUSTOMIZE=$(GOBIN)/kustomize
 else
-KUSTOMIZE=$(shell command -v kustomize)
+KUSTOMIZE=$(shell which kustomize)
 endif
 
 operator-sdk:
-ifeq (, $(shell command -v operator-sdk))
+ifeq (, $(shell which operator-sdk))
 	@{ \
 	set -e ;\
 	if [ "$(shell uname -s 2>/dev/null || echo Unknown)" == "Darwin" ] ; then \
@@ -459,7 +459,7 @@ else
   operator-sdk version | sed -n 's/.*"v\([^"]*\)".*/\1/p'; \
 	echo " If this is less than $(OPERATOR_SDK_VERSION) then please consider moving it aside and allowing the approved version to be downloaded."; \
 	}
-OPERATOR_SDK=$(shell command -v operator-sdk)
+OPERATOR_SDK=$(shell which operator-sdk)
 endif
 
 .PHONY: generate-crd $(BUNDLE_CAMEL_APIS) bundle bundle-build


### PR DESCRIPTION
With this PR we enabled the checks to run on downstream as well. We must make sure to disable those actions that we don't want/need to run (ie, changelog, dependabot, release, ...) and keep the ones that verify the build.