### PR TITLE
Small fixes for bundle generation

### DIFF
--- a/config/manifests/bases/camel-k.clusterserviceversion.yaml
+++ b/config/manifests/bases/camel-k.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     description: Red Hat Integration - Camel K is a lightweight integration platform,
       born on Kubernetes, with serverless superpowers.
     olm.skipRange: '>=1.6.7 <1.8.0'
-    operators.operatorframework.io/builder: operator-sdk-v1.3.0
+    operators.operatorframework.io/builder: operator-sdk-v1.16.0
     operators.operatorframework.io/internal-objects: '["builds.camel.apache.org","integrationkits.camel.apache.org","camelcatalogs.camel.apache.org"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     operators.openshift.io/valid-subscription: '["Red Hat Integration", "Red Hat Application Foundations", "Red Hat Camel K"]'

--- a/config/samples/bases/camel_v1_kamelet.yaml
+++ b/config/samples/bases/camel_v1_kamelet.yaml
@@ -35,7 +35,7 @@ spec:
     required:
     - message
     title: Example Timer
-  flow:
+  template:
     from:
       parameters:
         period: "#property:period"

--- a/script/Makefile
+++ b/script/Makefile
@@ -23,7 +23,7 @@ BUILDAH_VERSION := 1.14.0
 KANIKO_VERSION := 0.17.1
 INSTALL_DEFAULT_KAMELETS := true
 CONTROLLER_GEN_VERSION := v0.4.1
-OPERATOR_SDK_VERSION := v1.14.0
+OPERATOR_SDK_VERSION := v1.16.0
 KUSTOMIZE_VERSION := v4.1.2
 BASE_IMAGE ?= adoptopenjdk/openjdk11:slim
 LOCAL_REPOSITORY := /tmp/artifacts/m2
@@ -52,11 +52,13 @@ LINT_DEADLINE := 10m
 # olm bundle vars
 MANAGER := config/manager
 MANIFESTS := config/manifests
+BUNDLE_DIR := bundle
 CHANNELS ?= $(shell v=$(OPERATOR_VERSION) && echo "$${v%\.[0-9]}.x"),candidate,latest
 DEFAULT_CHANNEL ?= $(shell v=$(OPERATOR_VERSION) && echo "$${v%\.[0-9]}.x")
 PACKAGE := red-hat-camel-k
 CSV_VERSION := $(CUSTOM_VERSION:-SNAPSHOT=)
 CSV_NAME := $(PACKAGE).v$(CSV_VERSION)
+CSV_PRODUCT_NAME := $(PACKAGE)-operator.v$(CSV_VERSION)
 CSV_DISPLAY_NAME := Red Hat Integration - Camel K
 CSV_SUPPORT := Camel
 CSV_REPLACES := $(LAST_RELEASED_IMAGE_NAME).v$(LAST_RELEASED_VERSION)
@@ -530,6 +532,10 @@ endif
 	@# Adds the licence headers to the csv file
 	./script/add_license.sh bundle/manifests ./script/headers/yaml.txt
 	$(OPERATOR_SDK) bundle validate ./bundle
+# operator-sdk requires the name of the operator to be the PACKAGE
+# However, the historical name of the operator has the suffix 'operator' so this should
+# be added once the validation has been completed
+	@sed -i 's/  name: $(CSV_NAME)/  name: $(CSV_PRODUCT_NAME)/' $(BUNDLE_DIR)/manifests/$(CSV_FILENAME)
 
 # Build the bundle image.
 bundle-build: bundle


### PR DESCRIPTION
* Bump the operator-sdk version to 1.16 as being used to perform the generation

* Updates the samples to the correct syntax

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
