### PR TITLE
ENTESB-20686: Fixes OLM upgrade path from 1.8.x to 1.10

### DIFF
--- a/config/manifests/bases/camel-k.clusterserviceversion.yaml
+++ b/config/manifests/bases/camel-k.clusterserviceversion.yaml
@@ -26,7 +26,7 @@ metadata:
     createdAt: 2022-09-21T12:01:32Z
     description: Red Hat Integration - Camel K is a lightweight integration platform,
       born on Kubernetes, with serverless superpowers.
-    olm.skipRange: '>=1.6.7 <1.8.0'
+    olm.skipRange: '>=1.8.0 <1.10.0'
     operators.operatorframework.io/builder: operator-sdk-v1.16.0
     operators.operatorframework.io/internal-objects: '["builds.camel.apache.org","integrationkits.camel.apache.org","camelcatalogs.camel.apache.org"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2

--- a/script/Makefile
+++ b/script/Makefile
@@ -16,7 +16,7 @@
 VERSIONFILE := pkg/util/defaults/defaults.go
 VERSION ?= 1.10.0
 LAST_RELEASED_IMAGE_NAME := red-hat-camel-k-operator
-LAST_RELEASED_VERSION := 1.8.1
+LAST_RELEASED_VERSION := 1.8.2
 RUNTIME_VERSION ?= 1.15.0
 RHI_VERSION := 2022.Q4
 BUILDAH_VERSION := 1.14.0
@@ -76,7 +76,7 @@ STAGING_RUNTIME_REPO :=
 INSTALL_DEFAULT_KAMELETS ?= true
 KAMELET_CATALOG_REPO := https://github.com/apache/camel-kamelets.git
 # Optional branch for the default Kamelet catalog (change this to a tag before release)
-KAMELET_CATALOG_REPO_BRANCH := v0.7.1
+KAMELET_CATALOG_REPO_TAG := v0.7.1
 
 # When packaging artifacts into the docker image, you can "copy" them from local maven
 # or "download" them from Apache Snapshots and Maven Central


### PR DESCRIPTION
* csv
  - Modifies skipRange so that switching channels from 1.8 to 1.10 should ensure an upgrade is executed

* Makefile
  - Updates the last released version to 1.8.2...
  - Fixes porting error from main where the KAMELET_CATALOG_REPO_BRANCH had already been renamed to KAMELET_CATALOG_REPO_TAG

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
