### PR TITLE
chore(api): introduce itp shortname

### DIFF
--- a/config/crd/bases/camel.apache.org_integrationplatforms.yaml
+++ b/config/crd/bases/camel.apache.org_integrationplatforms.yaml
@@ -35,6 +35,7 @@ spec:
     plural: integrationplatforms
     shortNames:
     - ip
+    - itp
     singular: integrationplatform
   scope: Namespaced
   versions:

--- a/helm/camel-k/crds/crd-integration-platform.yaml
+++ b/helm/camel-k/crds/crd-integration-platform.yaml
@@ -35,6 +35,7 @@ spec:
     plural: integrationplatforms
     shortNames:
     - ip
+    - itp
     singular: integrationplatform
   scope: Namespaced
   versions:

--- a/pkg/apis/camel/v1/integrationplatform_types.go
+++ b/pkg/apis/camel/v1/integrationplatform_types.go
@@ -66,7 +66,7 @@ type IntegrationPlatformStatus struct {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=integrationplatforms,scope=Namespaced,shortName=ip,categories=kamel;camel
+// +kubebuilder:resource:path=integrationplatforms,scope=Namespaced,shortName=ip;itp,categories=kamel;camel
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`,description="The integration platform phase"


### PR DESCRIPTION
We need to deprecate IP as it is too generic and collide with many other CRs.

Closes CMLK-1265

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
