### PR TITLE
Fix: Add rbac back to bundle generation

### DIFF
--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -18,6 +18,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 # Labels to add to all resources and selectors.
+commonLabels:
+  app: camel-k
 
 resources:
 - ../manager
@@ -25,7 +27,13 @@ resources:
 - ../samples
 - ../scorecard
 - ../rbac
+- ../rbac/namespaced
 - ../rbac/openshift
+- ../rbac/openshift/namespaced
 
 patchesStrategicMerge:
 - patch-delete-user-cluster-role.yaml
+images:
+- name: registry-proxy.engineering.redhat.com/rh-osbs/integration-camel-k-rhel8-operator
+  newName: registry-proxy.engineering.redhat.com/rh-osbs/integration-camel-k-rhel8-operator
+  newTag: 2.2.0


### PR DESCRIPTION
The rbac resources were removed in a previous commit, this is to restore it.

<!-- Description -->

For context, the [commit that removed the rbac entries](https://github.com/jboss-fuse/camel-k/commit/62a2203368af33b426292938c19d79fbb9dd32c5#diff-fe545782dbfdb2c00c396b25f7a8990e1d4af2d68d02e25363dc54c837f8aac6).


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
