### PR TITLE
CMLK-1872: Fix manifest generation: don't modify the labels of selector (2.2.x)

### DIFF
--- a/config/manifests/global-labels.yaml
+++ b/config/manifests/global-labels.yaml
@@ -15,25 +15,11 @@
 # limitations under the License.
 # ---------------------------------------------------------------------------
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-# Labels to add to all resources and selectors.
-transformers:
-- global-labels.yaml
-
-resources:
-- ../manager
-- ../crd
-- ../samples
-- ../scorecard
-- ../rbac
-- ../rbac/namespaced
-- ../rbac/openshift
-- ../rbac/openshift/namespaced
-
-patchesStrategicMerge:
-- patch-delete-user-cluster-role.yaml
-images:
-- name: registry-proxy.engineering.redhat.com/rh-osbs/integration-camel-k-rhel8-operator
-  newName: registry-proxy.engineering.redhat.com/rh-osbs/integration-camel-k-rhel8-operator
-  newTag: 2.2.0
+kind: LabelTransformer
+metadata:
+  name: global-labels
+labels:
+  app: camel-k
+fieldSpecs:
+- path: metadata/labels
+  create: true


### PR DESCRIPTION
CMLK-1872 Upgrade test olm_upgrade_test.go fails with no operators found in channel stable-v2 
https://issues.redhat.com/browse/CMLK-1872

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
