### PR TITLE
Revert "fix(ci): brew failure due to non official builder tool"

### DIFF
--- a/script/Makefile
+++ b/script/Makefile
@@ -116,7 +116,7 @@ else
 $(warning Could not retrieve a valid Git Commit)
 endif
 
-#GOFLAGS = -ldflags "$(GOLDFLAGS)" -trimpath
+GOFLAGS = -ldflags "$(GOLDFLAGS)" -trimpath
 
 define LICENSE_HEADER
 Licensed to the Apache Software Foundation (ASF) under one or more
@@ -213,7 +213,7 @@ codegen-tools-install: controller-gen
 
 build: codegen build-resources test build-kamel build-compile-integration-tests
 
-ci-build: codegen set-version check-licenses dir-licenses build-kamel cross-compile
+ci-build: clean codegen set-version check-licenses dir-licenses build-kamel cross-compile
 
 do-build: gotestfmt-install
 ifeq ($(DO_TEST_PREBUILD),true)


### PR DESCRIPTION
This reverts commit 7e623d5cee19d76ee64eb6ea00c1d9208211b4ec.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
