### PR TITLE
Limit the OCP versions to v4.12-v4.17 in bundle metadata

### DIFF
--- a/script/Makefile
+++ b/script/Makefile
@@ -536,6 +536,7 @@ ifneq ($(origin PACKAGE), undefined)
 BUNDLE_PACKAGE := --package=$(PACKAGE)
 endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL) $(BUNDLE_PACKAGE)
+BUNDLE_METADATA_OPENSHIFT_VERSION ?= $(shell grep com.redhat.openshift.versions script/post_bundle_gen.sh |awk -F= '{print $2}'|sed 's/"//g')
 
 #
 # Tailor the manifest according to default values for this project
@@ -568,6 +569,7 @@ else
 endif
 	@# Adds the licence headers to the csv file
 	./script/add_license.sh bundle/manifests ./script/headers/yaml.txt
+	@echo "  com.redhat.openshift.versions : $(BUNDLE_METADATA_OPENSHIFT_VERSION)" >> ./bundle/metadata/annotations.yaml
 	$(OPERATOR_SDK) bundle validate ./bundle
 # operator-sdk requires the name of the operator to be the PACKAGE
 # However, the historical name of the operator has the suffix 'operator' so this should

--- a/script/post_bundle_gen.sh
+++ b/script/post_bundle_gen.sh
@@ -55,7 +55,7 @@ LABEL com.redhat.delivery.operator.bundle=true
 
 # Tells the pipeline which versions of OpenShift the operator supports.
 # This is used to control which index images should include this operator.
-LABEL com.redhat.openshift.versions="v4.12"
+LABEL com.redhat.openshift.versions="v4.12-v4.17"
 
 # The rest of these labels are copies of the same content in annotations.yaml and are needed by OLM
 # Note the package name and channels which are very important!


### PR DESCRIPTION
<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
